### PR TITLE
Fix <text> </text> tag in comments

### DIFF
--- a/src/main/java/org/spdx/tag/BuildDocument.java
+++ b/src/main/java/org/spdx/tag/BuildDocument.java
@@ -1,18 +1,7 @@
 /**
- * Copyright (c) 2011 Source Auditor Inc.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2011 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
  */
 package org.spdx.tag;
 

--- a/src/main/java/org/spdx/tag/CommonCode.java
+++ b/src/main/java/org/spdx/tag/CommonCode.java
@@ -1,33 +1,7 @@
 /**
-
- * Copyright (c) 2010 Source Auditor Inc.
-
- *
-
- *   Licensed under the Apache License, Version 2.0 (the "License");
-
- *   you may not use this file except in compliance with the License.
-
- *   You may obtain a copy of the License at
-
- *
-
- *       http://www.apache.org/licenses/LICENSE-2.0
-
- *
-
- *   Unless required by applicable law or agreed to in writing, software
-
- *   distributed under the License is distributed on an "AS IS" BASIS,
-
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-
- *   See the License for the specific language governing permissions and
-
- *   limitations under the License.
-
- *
-
+ * SPDX-FileCopyrightText: Copyright (c) 2015 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
  */
 package org.spdx.tag;
 

--- a/src/main/java/org/spdx/tag/HandBuiltParser.java
+++ b/src/main/java/org/spdx/tag/HandBuiltParser.java
@@ -1,18 +1,7 @@
 /**
- * Copyright (c) 2013 Source Auditor Inc.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2013 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
 */
 package org.spdx.tag;
 
@@ -23,11 +12,11 @@ import java.util.regex.Pattern;
  * I'm hoping this is a temporary solution.  This is a hand built parser to parse
  * SPDX tag files.  It replaces the current ANTL based parser which has a defect
  * where any lines starting with a text ending with a : is treated as a tag even
- * if it is in <text> </text>
+ * if it is in <pre>&lt;text&gt; &lt;/text&gt;</pre>.
  *
- * The interface is similar to the generated ANTLR code
+ * The interface is similar to the generated ANTLR code.
+ *
  * @author Gary O'Neall
- *
  */
 public class HandBuiltParser {
 

--- a/src/main/java/org/spdx/tag/InvalidFileFormatException.java
+++ b/src/main/java/org/spdx/tag/InvalidFileFormatException.java
@@ -1,19 +1,8 @@
 /**
- * Copyright (c) 2017 Source Auditor Inc.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
-*/
+ * SPDX-FileCopyrightText: Copyright (c) 2017 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.spdx.tag;
 
 import org.spdx.core.InvalidSPDXAnalysisException;
@@ -22,7 +11,6 @@ import org.spdx.core.InvalidSPDXAnalysisException;
  * Exceptions for invalid SPDX file format
  *
  * @author Rohit Lodha
- *
  */
 public class InvalidFileFormatException extends InvalidSPDXAnalysisException {
 

--- a/src/main/java/org/spdx/tag/InvalidSpdxTagFileException.java
+++ b/src/main/java/org/spdx/tag/InvalidSpdxTagFileException.java
@@ -1,19 +1,8 @@
 /**
- * Copyright (c) 2012 Source Auditor Inc.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
-*/
+ * SPDX-FileCopyrightText: Copyright (c) 2012 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.spdx.tag;
 
 import org.spdx.core.InvalidSPDXAnalysisException;
@@ -22,7 +11,6 @@ import org.spdx.core.InvalidSPDXAnalysisException;
  * Exceptions for errors in a SPDX tag format file
  *
  * @author Gary O'Neall
- *
  */
 public class InvalidSpdxTagFileException extends InvalidSPDXAnalysisException {
 

--- a/src/main/java/org/spdx/tag/NoCommentInputStream.java
+++ b/src/main/java/org/spdx/tag/NoCommentInputStream.java
@@ -1,19 +1,8 @@
 /**
- * Copyright (c) 2013 Source Auditor Inc.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
-*/
+ * SPDX-FileCopyrightText: Copyright (c) 2013 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.spdx.tag;
 
 import java.io.BufferedReader;
@@ -25,12 +14,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * @author Gary O'Neall
- *
  * Input stream which filters out any SPDX tag/value comments
  * Any new line which begins with a # is skipped until the end of line except
- * if it is within a <text> </text> wrapper
+ * if it is within a <pre>&lt;text&gt; &lt;/text&gt;</pre> wrapper.
  *
+ * @author Gary O'Neall
  */
 public class NoCommentInputStream extends InputStream {
 

--- a/src/main/java/org/spdx/tag/RecognitionException.java
+++ b/src/main/java/org/spdx/tag/RecognitionException.java
@@ -1,20 +1,6 @@
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- *
- * SPDX-License-Identifier: Apache-2.0
- * 
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  */
 package org.spdx.tag;
@@ -24,7 +10,6 @@ import org.spdx.core.InvalidSPDXAnalysisException;
 /**
  * Parser/Scanner recognition errors
  * @author Gary O'Neall
- *
  */
 public class RecognitionException extends InvalidSPDXAnalysisException {
 

--- a/src/main/java/org/spdx/tag/SpdxTagValueConstants.properties
+++ b/src/main/java/org/spdx/tag/SpdxTagValueConstants.properties
@@ -1,21 +1,9 @@
-#
-# Copyright (c) 2011 Source Auditor Inc.
-#
-#   Licensed under the Apache License, Version 2.0 (the "License");
-#   you may not use this file except in compliance with the License.
-#   You may obtain a copy of the License at
-#
-#       http://www.apache.org/licenses/LICENSE-2.0
-#
-#   Unless required by applicable law or agreed to in writing, software
-#   distributed under the License is distributed on an "AS IS" BASIS,
-#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#   See the License for the specific language governing permissions and
-#   limitations under the License.
+# SPDX-FileCopyrightText: Copyright (c) 2011 Source Auditor Inc.
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
 #
 #
 # @author Rana Rahal, Protecode Inc.
-
 
     
 # File Headers
@@ -53,20 +41,20 @@ PROP_PROJECT_NAME=ArtifactOfProjectName:
 PROP_PROJECT_HOMEPAGE=ArtifactOfProjectHomePage: 
 PROP_PROJECT_URI=ArtifactOfProjectURI: 
 	
-#SPDX Document Properties
+# SPDX Document Properties
 PROP_SPDX_VERSION=SPDXVersion: 
 PROP_SPDX_DATA_LICENSE=DataLicense: 
 PROP_SPDX_COMMENT=DocumentComment: 
 PROP_DOCUMENT_NAME=DocumentName: 
 PROP_DOCUMENT_NAMESPACE=DocumentNamespace: 
 	
-#SPDX CreationInfo Properties
+# SPDX CreationInfo Properties
 PROP_CREATION_CREATOR=Creator: 
 PROP_CREATION_CREATED=Created: 
 PROP_CREATION_COMMENT=CreatorComment: 
 PROP_LICENSE_LIST_VERSION = LicenseListVersion: 
 	
-#SPDX Package Properties
+# SPDX Package Properties
 PROP_PACKAGE_DECLARED_NAME=PackageName: 
 PROP_PACKAGE_COMMENT=PackageComment: 
 PROP_PACKAGE_FILE_NAME=PackageFileName: 
@@ -94,7 +82,7 @@ PROP_PACKAGE_BUILT_DATE=BuiltDate:
 PROP_PACKAGE_RELEASE_DATE=ReleaseDate: 
 PROP_PACKAGE_VALID_UNTIL_DATE=ValidUntilDate: 
 	
-#SPDX License Properties
+# SPDX License Properties
 PROP_LICENSE_ID=LicenseID: 
 PROP_LICENSE_TEXT=licenseText: 
 PROP_EXTRACTED_TEXT=ExtractedText: 
@@ -102,7 +90,7 @@ PROP_LICENSE_COMMENT=LicenseComment:
 PROP_LICENSE_NAME=LicenseName: 
 PROP_SOURCE_URLS=LicenseCrossReference: 
 	
-#SPDX File Properties
+# SPDX File Properties
 PROP_FILE_NAME=FileName: 
 PROP_FILE_TYPE=FileType: 
 PROP_FILE_LICENSE=LicenseConcluded: 
@@ -128,7 +116,7 @@ PROP_SNIPPET_COMMENT=SnippetComment:
 PROP_SNIPPET_NAME=SnippetName: 
 PROP_SNIPPET_SEEN_LICENSE=LicenseInfoInSnippet: 
 
-#SPDX Review Properties
+# SPDX Review Properties
 PROP_REVIEW_REVIEWER=Reviewer: 
 PROP_REVIEW_DATE=ReviewDate: 
 PROP_REVIEW_COMMENT=ReviewComment: 

--- a/src/main/java/org/spdx/tag/SpdxViewerConstants.properties
+++ b/src/main/java/org/spdx/tag/SpdxViewerConstants.properties
@@ -1,21 +1,8 @@
-#
-# Copyright (c) 2011 Source Auditor Inc.
-#
-#   Licensed under the Apache License, Version 2.0 (the "License");
-#   you may not use this file except in compliance with the License.
-#   You may obtain a copy of the License at
-#
-#       http://www.apache.org/licenses/LICENSE-2.0
-#
-#   Unless required by applicable law or agreed to in writing, software
-#   distributed under the License is distributed on an "AS IS" BASIS,
-#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#   See the License for the specific language governing permissions and
-#   limitations under the License.
-#
+# SPDX-FileCopyrightText: Copyright (c) 2011 Source Auditor Inc.
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
 #
 # @author Rana Rahal, Protecode Inc.
-
 
     
 # File Headers

--- a/src/main/java/org/spdx/tag/TagValueBehavior.java
+++ b/src/main/java/org/spdx/tag/TagValueBehavior.java
@@ -1,18 +1,7 @@
 /**
- * Copyright (c) 2011 Source Auditor Inc.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2011 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
  */
 package org.spdx.tag;
 

--- a/src/main/java/org/spdx/tag/package-info.java
+++ b/src/main/java/org/spdx/tag/package-info.java
@@ -1,9 +1,12 @@
 /**
- * 
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 /**
- * @author Gary O'Neall
- *
  * Package to support the SPDX tag/value format
+ *
+ * @author Gary O'Neall
  */
 package org.spdx.tag;

--- a/src/main/java/org/spdx/tagvaluestore/TagValueStore.java
+++ b/src/main/java/org/spdx/tagvaluestore/TagValueStore.java
@@ -1,20 +1,6 @@
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- *
- * SPDX-License-Identifier: Apache-2.0
- * 
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  */
 package org.spdx.tagvaluestore;
@@ -54,7 +40,6 @@ import org.spdx.tag.RecognitionException;
  * SPDX Store implementing serializers and deserializers for the Tag/Value format
  * 
  * @author Gary O'Neall
- *
  */
 public class TagValueStore extends ExtendedSpdxStore implements ISerializableModelStore {
 	

--- a/src/test/java/org/spdx/tag/NoCommentInputStreamTest.java
+++ b/src/test/java/org/spdx/tag/NoCommentInputStreamTest.java
@@ -1,25 +1,12 @@
 /**
- * Copyright (c) 2013 Source Auditor Inc.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
-*/
+ * SPDX-FileCopyrightText: Copyright (c) 2013 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.spdx.tag;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-
-import org.spdx.tag.NoCommentInputStream;
 
 import junit.framework.TestCase;
 

--- a/src/test/java/org/spdx/tag/TestBuildDocument.java
+++ b/src/test/java/org/spdx/tag/TestBuildDocument.java
@@ -1,19 +1,8 @@
 /**
- * Copyright (c) 2016 Source Auditor Inc.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
-*/
+ * SPDX-FileCopyrightText: Copyright (c) 2016 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.spdx.tag;
 
 import java.io.ByteArrayInputStream;
@@ -59,7 +48,6 @@ import junit.framework.TestCase;
 
 /**
  * @author Gary O'Neall
- *
  */
 public class TestBuildDocument extends TestCase {
 

--- a/src/test/java/org/spdx/tagvaluestore/TagValueStoreTest.java
+++ b/src/test/java/org/spdx/tagvaluestore/TagValueStoreTest.java
@@ -1,20 +1,6 @@
 /**
- * Copyright (c) 2020 Source Auditor Inc.
- *
- * SPDX-License-Identifier: Apache-2.0
- * 
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2020 Source Auditor Inc.
+ * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  */
 package org.spdx.tagvaluestore;
@@ -49,7 +35,6 @@ import junit.framework.TestCase;
 
 /**
  * @author Gary O'Neall
- *
  */
 public class TagValueStoreTest extends TestCase {
 	


### PR DESCRIPTION
The tag is not recognisable by Javadoc, has to escaped it.